### PR TITLE
✨ Add color options

### DIFF
--- a/todol/__main__.py
+++ b/todol/__main__.py
@@ -17,13 +17,15 @@ from pathlib import Path
 from typing import Dict, List
 
 from . import __version__
-from . import _interface as interface
+from . import _interface as intf
 from . import _utils, todo_objects
+from ._opts import color_options
 
 parser = argparse.ArgumentParser(
     description="A todo list CLI tool",
     prog="todol",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    parents=[color_options],
 )
 parser.add_argument(
     "--version", action="version", version="%(prog)s {}".format(__version__)
@@ -31,7 +33,9 @@ parser.add_argument(
 
 subparsers = parser.add_subparsers(dest="command")
 
-list_parser = subparsers.add_parser("list", help="List todos", aliases=("l"))
+list_parser = subparsers.add_parser(
+    "list", help="List todos", aliases=("l"), parents=[color_options]
+)
 list_parser.add_argument(
     "type",
     choices=("todo", "finished", "fin"),
@@ -39,7 +43,9 @@ list_parser.add_argument(
     default="todo",
     help="The type of todo to list",
 )
-init_parser = subparsers.add_parser("init", help="Initialize todol")
+init_parser = subparsers.add_parser(
+    "init", help="Initialize todol", parents=[color_options]
+)
 init_parser.add_argument(
     "--no-shell",
     action="store_true",
@@ -47,7 +53,9 @@ init_parser.add_argument(
     dest="no_shell",
 )
 
-add_parser = subparsers.add_parser("add", help="Add a todo", aliases=("a"))
+add_parser = subparsers.add_parser(
+    "add", help="Add a todo", aliases=("a"), parents=[color_options]
+)
 add_parser.add_argument("todo", help="The todo to add.", type=_utils.sim_str)
 
 due_dates = add_parser.add_mutually_exclusive_group()
@@ -70,7 +78,10 @@ due_dates.add_argument(
 )
 
 remove_parser = subparsers.add_parser(
-    "remove", help="Remove todo(s) without finishing them", aliases=("r", "remove")
+    "remove",
+    help="Remove todo(s) without finishing them",
+    aliases=("r", "remove"),
+    parents=[color_options],
 )
 remove_parser.add_argument(
     "todo",
@@ -78,7 +89,7 @@ remove_parser.add_argument(
 )
 
 finish_parser = subparsers.add_parser(
-    "finish", help="Finish todo(s)", aliases=("f", "do")
+    "finish", help="Finish todo(s)", aliases=("f", "do"), parents=[color_options]
 )
 finish_parser.add_argument(
     "todo",
@@ -123,6 +134,7 @@ def main() -> None:  # TODO: REFACTOR this to an object
 
     todol_dir = Path("~/.config/todol").expanduser()
     todo_index = todol_dir.joinpath("todos.json")
+    interface = intf.Color(no_color=args.no_color, force_color=args.force_color)  # type: ignore
 
     def _get_todo_data() -> Dict[str, List[Dict[str, str]]]:
         try:

--- a/todol/_interface.py
+++ b/todol/_interface.py
@@ -11,10 +11,9 @@ See https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#color-codes
 
 """
 
-import os
-import platform
+import os as _os
 import shutil as _shutil
-import sys
+import sys as _sys
 from typing import Dict, Optional, Tuple
 
 try:
@@ -27,7 +26,7 @@ except ImportError:
 
 class Colors:
     _ansi_prefix: str = "\033["
-    colors_dict = {
+    colors_dict: Dict[str, str] = {
         "red": "31",
         "green": "32",
         "yellow": "33",
@@ -37,33 +36,19 @@ class Colors:
         "white": "37",
         "black": "30",
     }
-    bg_dict = {key: str(int(value) + 10) for key, value in colors_dict.items()}
+    bg_dict: Dict[str, str] = {
+        key: str(int(value) + 10) for key, value in colors_dict.items()
+    }
     graphic_modes = {"reset": "0", "bold": "1", "dim": "2"}
 
     def __init__(self, force: bool = False, no_color: bool = False) -> None:
         if force and no_color:
             raise ValueError("arguments 'force' and 'no_color' are mutually exclusive")
-        self._print_colors: bool = force or (not no_color and sys.stdout.isatty())
+        self._print_colors: bool = force or (not no_color and _sys.stdout.isatty())
 
-    def __getattribute__(self, attr: str) -> str:
+    def __getattr__(self, attr: str) -> str:
         if not self._print_colors:
             return ""
-        cleaned = "".join(
-            (
-                letter
-                for letter in attr.strip().lower()
-                if letter in "qwertyuiopasdfghjklzxcvbnm_"
-            )
-        ).strip("_")
-        if cleaned or not "".join(cleaned):
-            raise AttributeError("invalid color format")
-        mode = cleaned.split("_as_")
-        try:
-            parsed = parse_fore_back(cleaned)
-        except ValueError:
-            parsed = parse_fore_back(mode[0])
-        finally:
-            color = f"{parsed[0]};{parsed[1]}m" if parsed[1] else f"{parsed[0]}m"
 
         def parse_fore_back(to_parse: str) -> Tuple[str, Optional[str]]:
             string = to_parse.split("_on_")
@@ -88,11 +73,26 @@ class Colors:
 
             raise ValueError("invalid color format: too many 'on's")
 
+        cleaned = "".join(
+            letter
+            for letter in attr.strip().lower()
+            if letter in "qwertyuiopasdfghjklzxcvbnm_"
+        ).strip("_")
+        if not (cleaned or "".join(cleaned)):
+            raise AttributeError(f"invalid color format: got {cleaned}")
+
+        mode = cleaned.split("_as_")
         if self.graphic_modes.get(cleaned):
             return self._ansi_prefix + f"{self.graphic_modes[cleaned]}m"
 
+        try:
+            parsed = parse_fore_back(cleaned)
+        except ValueError:
+            parsed = parse_fore_back(mode[0])
+        color = f"{parsed[0]};{parsed[1]}m" if parsed[1] else f"{parsed[0]}m"
+
         if len(mode) == 1:
-            return self.ansi_prefix + color
+            return self._ansi_prefix + color
 
         if len(mode) == 2:
             try:
@@ -133,14 +133,14 @@ BACKGROUND_GREEN: str = _ansi_prefix + "42m"
 BACKGROUND_MAGENTA: str = _ansi_prefix + "45m"
 BACKGROUND_CYAN: str = _ansi_prefix + "46m"
 
-_trash = open(os.devnull, "w")
+_trash = open(_os.devnull, "w")
 
 
 def info(msg: str, *, err: bool = False, shutup: bool = False) -> None:
     """Print an informational message"""
     print(
         "%sINFO: %s%s%s" % (BLUE, YELLOW, msg, RESET),
-        file=(sys.stderr if err else sys.stdout) if not shutup else _trash,
+        file=(_sys.stderr if err else _sys.stdout) if not shutup else _trash,
     )
 
 
@@ -148,7 +148,7 @@ def warn(msg: str, *, err: bool = False, shutup: bool = False) -> None:
     """Print a warning"""
     print(
         "\N{WARNING SIGN} %sWARNING: %s%s" % (YELLOW, msg, RESET),
-        file=(sys.stderr if err else sys.stdout) if not shutup else _trash,
+        file=(_sys.stderr if err else _sys.stdout) if not shutup else _trash,
     )
 
 
@@ -157,10 +157,10 @@ def error(msg: str, *, err: bool = False, shutup: bool = False) -> None:
     # TODO: Change error system to make use of exceptions
     print(
         "\N{COLLISION SYMBOL} %sERROR: %s%s" % (RED, msg, RESET),
-        file=(sys.stderr if err else sys.stdout) if not shutup else _trash,
+        file=(_sys.stderr if err else _sys.stdout) if not shutup else _trash,
     )
 
 
 def success(msg: str = "Success!", *, err: bool = False) -> None:
     """Print a success message"""
-    print("%s%s%s" % (GREEN, msg, RESET), file=(sys.stderr if err else sys.stdout))
+    print("%s%s%s" % (GREEN, msg, RESET), file=(_sys.stderr if err else _sys.stdout))

--- a/todol/_opts.py
+++ b/todol/_opts.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# type: ignore
+"""
+Initial author: Bryan Hu.
+
+@ThatXliner.
+
+Version: v0.1.0
+
+A file of parsers for argparse
+
+"""
+import argparse
+
+__all__ = ["color_options"]
+color_options: argparse.ArgumentParser = argparse.ArgumentParser(add_help=False)
+
+
+class BooleanOptionalAction(argparse.Action):
+    """A backport of argparse.BooleanOptionalAction"""
+
+    # pylint: disable=C,R,W
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
+
+        _option_strings = []
+        for option_string in option_strings:
+            _option_strings.append(option_string)
+
+            if option_string.startswith("--"):
+                option_string = "--no-" + option_string[2:]
+                _option_strings.append(option_string)
+
+        # if help is not None and default is not None:
+        #     help += f" (default: {default})"
+
+        super().__init__(
+            option_strings=_option_strings,
+            dest=dest,
+            nargs=0,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string in self.option_strings:
+            setattr(namespace, self.dest, not option_string.startswith("--no-"))
+
+    def format_usage(self):
+        return " | ".join(self.option_strings)
+
+
+opts = color_options.add_mutually_exclusive_group()
+
+opts.add_argument(
+    "--no-color", action="store_true", help="Don't print color", dest="no_color"
+)
+opts.add_argument(
+    "--force-color",
+    action="store_true",
+    help="Force color output even if not printing to a terminal",
+    dest="force_color",
+)


### PR DESCRIPTION
This pull request resolves #5 by adding 2 **new** mutually exclusive options:

 - `--force-color`: This will force the printing of ANSI colors even if not printing to a terminal
 - `--no-color`: Disables ANSI colors

New code changes:
 - Subcommands and main parser will have `color_options` `ArgumenrParser` object as `parent`.
 - New file `_opts.py` for holding command_line options of sorts